### PR TITLE
feat: 이미지 처리 (local)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,14 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
 
+	//scrimage
+	implementation "com.sksamuel.scrimage:scrimage-core:4.0.32"
+	implementation "com.sksamuel.scrimage:scrimage-formats-extra:4.0.32"
+	implementation "com.sksamuel.scrimage:scrimage-webp:4.0.32"
+
+	//io
+	implementation 'commons-io:commons-io:2.6'
+
 	//test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/ktb/community/controller/image/ImageController.java
+++ b/src/main/java/com/ktb/community/controller/image/ImageController.java
@@ -1,0 +1,25 @@
+package com.ktb.community.controller.image;
+
+import com.ktb.community.dto.image.ImageRequest;
+import com.ktb.community.dto.image.ImageResponse;
+import com.ktb.community.service.image.ImageService;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/images")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    public ImageController(final ImageService imageService) {
+        this.imageService = imageService;
+    }
+
+    @PostMapping("")
+    public ImageResponse imageUpload(@RequestPart("file") MultipartFile file,
+                                     @RequestPart("imageRequest")ImageRequest imageRequest) {
+
+        return imageService.uploadImage(imageRequest, file);
+    }
+}

--- a/src/main/java/com/ktb/community/dto/image/ImageRequest.java
+++ b/src/main/java/com/ktb/community/dto/image/ImageRequest.java
@@ -1,0 +1,8 @@
+package com.ktb.community.dto.image;
+
+import com.ktb.community.global.enums.ImageType;
+
+public record ImageRequest(
+        ImageType type
+) {
+}

--- a/src/main/java/com/ktb/community/dto/image/ImageResponse.java
+++ b/src/main/java/com/ktb/community/dto/image/ImageResponse.java
@@ -1,0 +1,6 @@
+package com.ktb.community.dto.image;
+
+public record ImageResponse(
+        String imageUrl
+) {
+}

--- a/src/main/java/com/ktb/community/dto/post/response/PostCounterResponse.java
+++ b/src/main/java/com/ktb/community/dto/post/response/PostCounterResponse.java
@@ -1,20 +1,22 @@
 package com.ktb.community.dto.post.response;
 
 import com.ktb.community.domain.post_stats.PostStats;
+import com.ktb.community.global.processor.NumberProcessor;
 import lombok.Builder;
 
 @Builder
 public record PostCounterResponse(
-        long likes,
-        long comments,
-        long views
+        String likes,
+        String comments,
+        String views
 ) {
 
     public static PostCounterResponse from(PostStats postStats) {
         return PostCounterResponse.builder()
-                .likes(postStats.getLikeCount())
-                .comments(postStats.getCommentCount())
-                .views(postStats.getViewCount())
+                .likes(NumberProcessor.getFormatNumber(postStats.getLikeCount()))
+                .comments(NumberProcessor.getFormatNumber(postStats.getCommentCount()))
+                .views(NumberProcessor.getFormatNumber(postStats.getViewCount()))
                 .build();
     }
+
 }

--- a/src/main/java/com/ktb/community/global/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/community/global/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         request -> {
                             request.requestMatchers(HttpMethod.POST, "/members").permitAll();
-                            request.requestMatchers(HttpMethod.GET, "/members/nickname-validation", "members/email-validation").permitAll();
+                            request.requestMatchers("/images/**").permitAll();
+                            request.requestMatchers(HttpMethod.GET, "/members/nickname-validation", "/members/email-validation").permitAll();
                             request.requestMatchers( "/auth").permitAll().requestMatchers(HttpMethod.DELETE, "/auth").authenticated();
                             request.anyRequest().authenticated();
                         }

--- a/src/main/java/com/ktb/community/global/config/WebConfig.java
+++ b/src/main/java/com/ktb/community/global/config/WebConfig.java
@@ -1,15 +1,21 @@
 package com.ktb.community.global.config;
 
 import com.ktb.community.global.resolver.LoginResolver;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.nio.file.Paths;
 import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
 
     private final LoginResolver loginResolver;
 
@@ -29,4 +35,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("*")
                 .allowCredentials(true);
     }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:" + Paths.get(uploadDir).toAbsolutePath() + "/");
+    }
+
 }

--- a/src/main/java/com/ktb/community/global/enums/FileType.java
+++ b/src/main/java/com/ktb/community/global/enums/FileType.java
@@ -1,0 +1,5 @@
+package com.ktb.community.global.enums;
+
+public enum FileType {
+    ORIGINAL,WEBP
+}

--- a/src/main/java/com/ktb/community/global/enums/ImageType.java
+++ b/src/main/java/com/ktb/community/global/enums/ImageType.java
@@ -1,0 +1,18 @@
+package com.ktb.community.global.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ImageType {
+    PROFILE, POST;
+
+    @JsonCreator
+    public static ImageType from(String value) {
+        return ImageType.valueOf(value.toUpperCase());
+    }
+
+    @JsonValue
+    public String toValue() {
+        return name();
+    }
+}

--- a/src/main/java/com/ktb/community/global/processor/ImageProcessor.java
+++ b/src/main/java/com/ktb/community/global/processor/ImageProcessor.java
@@ -1,0 +1,35 @@
+package com.ktb.community.global.processor;
+
+import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.webp.WebpWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Component
+public class ImageProcessor {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+
+    public byte[] convertToWebp(MultipartFile multipartFile) {
+        try {
+            ImmutableImage image = ImmutableImage.loader().fromStream(multipartFile.getInputStream());
+            return image.bytes(WebpWriter.DEFAULT);
+        } catch (IOException e) {
+            throw new IllegalStateException("WEBP 변환 실패: " + e.getMessage(), e);
+        }
+    }
+
+    public byte[] convertToWebpWithLossLess(MultipartFile multipartFile) {
+        try {
+            ImmutableImage image = ImmutableImage.loader().fromStream(multipartFile.getInputStream());
+            return image.bytes(WebpWriter.DEFAULT.withLossless());
+        } catch (IOException e) {
+            throw new IllegalStateException("WEBP 변환 실패: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/ktb/community/global/processor/NumberProcessor.java
+++ b/src/main/java/com/ktb/community/global/processor/NumberProcessor.java
@@ -1,0 +1,12 @@
+package com.ktb.community.global.processor;
+
+public class NumberProcessor {
+
+    public static String getFormatNumber(long number) {
+        if(number >= 1000){
+            number = number / 1000;
+            return String.valueOf(number)+"K";
+        }
+        return String.valueOf(number);
+    }
+}

--- a/src/main/java/com/ktb/community/repository/member/MemberJpaRepository.java
+++ b/src/main/java/com/ktb/community/repository/member/MemberJpaRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(final String email);
+    Optional<Member> findByNickname(final String nickname);
     boolean existsByNickname(final String nickname);
     boolean existsByEmail(final String email);
 }

--- a/src/main/java/com/ktb/community/repository/member/MemberRepository.java
+++ b/src/main/java/com/ktb/community/repository/member/MemberRepository.java
@@ -9,5 +9,6 @@ public interface MemberRepository {
     Member getById(final long id);
     Optional<Member> findByEmail(final String email);
     boolean existsNickname(String nickname);
+    Optional<Member> findByNickname(String nickname);
     boolean existsEmail(String email);
 }

--- a/src/main/java/com/ktb/community/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/ktb/community/repository/member/MemberRepositoryImpl.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.server.ResponseStatusException;
 
+import javax.swing.text.html.Option;
 import java.util.Optional;
 
 @Repository
@@ -29,6 +30,11 @@ public class MemberRepositoryImpl implements MemberRepository {
     @Override
     public Optional<Member> findByEmail(final String email) {
         return memberJpaRepository.findByEmail(email);
+    }
+
+    @Override
+    public Optional<Member> findByNickname(String nickname){
+        return memberJpaRepository.findByNickname(nickname);
     }
 
     @Override

--- a/src/main/java/com/ktb/community/service/image/ImageService.java
+++ b/src/main/java/com/ktb/community/service/image/ImageService.java
@@ -1,0 +1,9 @@
+package com.ktb.community.service.image;
+
+import com.ktb.community.dto.image.ImageRequest;
+import com.ktb.community.dto.image.ImageResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageService {
+    ImageResponse uploadImage(final ImageRequest imageRequest, final MultipartFile multipartFile);
+}

--- a/src/main/java/com/ktb/community/service/image/LocalImageServiceImpl.java
+++ b/src/main/java/com/ktb/community/service/image/LocalImageServiceImpl.java
@@ -1,0 +1,90 @@
+package com.ktb.community.service.image;
+
+import com.ktb.community.dto.image.ImageRequest;
+import com.ktb.community.dto.image.ImageResponse;
+import com.ktb.community.global.processor.ImageProcessor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+import static com.ktb.community.global.enums.FileType.ORIGINAL;
+import static com.ktb.community.global.enums.FileType.WEBP;
+
+import org.apache.commons.io.FilenameUtils;
+
+
+@Service
+public class LocalImageServiceImpl implements ImageService{
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    @Value("${file.image-base-url}")
+    private String imageBaseUrl;
+
+    private final ImageProcessor imageProcessor;
+
+    public LocalImageServiceImpl(final ImageProcessor imageProcessor) {
+        this.imageProcessor = imageProcessor;
+    }
+
+    @Override
+    public ImageResponse uploadImage(final ImageRequest imageRequest, final MultipartFile multipartFile)  {
+        String uuid = UUID.randomUUID().toString();
+
+        String originalPath = saveOriginalFile(imageRequest, multipartFile, uuid);
+        String webPPath = saveWebPFile(imageRequest, multipartFile, uuid);
+        return new ImageResponse(webPPath.toString());
+    }
+
+    private String saveOriginalFile(final ImageRequest imageRequest, final MultipartFile multipartFile, final String uuid) {
+        try {
+            Path saveOriginalDir = Paths
+                    .get(uploadDir, imageRequest.type().toString().toLowerCase()+"/"+ORIGINAL)
+                    .normalize();
+
+            Files.createDirectories(saveOriginalDir);
+
+            String storedName = uuid + "_" + multipartFile.getOriginalFilename();
+            Path originalPath = saveOriginalDir.resolve(storedName);
+
+            Files.copy(multipartFile.getInputStream(), originalPath, StandardCopyOption.REPLACE_EXISTING);
+
+            return originalPath.toString();
+        }catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String saveWebPFile(final ImageRequest imageRequest, final MultipartFile multipartFile, final String uuid) {
+        try {
+
+            String relativePath = imageRequest.type().toString().toLowerCase()+"/"+WEBP;
+            Path saveWebPDir = Paths
+                    .get(uploadDir, relativePath)
+                    .normalize();
+            Files.createDirectories(saveWebPDir);
+
+            byte[] webpByte = imageProcessor.convertToWebp(multipartFile);
+            String baseName = FilenameUtils.getBaseName(multipartFile.getOriginalFilename());
+
+            String webPStoredName = uuid + "_" + baseName + ".webp";
+            Path webPPath = saveWebPDir.resolve(webPStoredName);
+
+            Files.write(webPPath, webpByte);
+
+            return imageBaseUrl+relativePath+"/"+webPStoredName;
+        }catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,3 +25,15 @@ spring:
     key: ${JWT_KEY}
     access_exp_time: ${ACCESS_EXP}
     refresh_exp_time: ${REFRESH_EXP}
+
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 40MB
+    server:
+      tomcat:
+        max-swallow-size: 40MB
+
+file:
+  upload-dir: ${LOCAL_UPLOAD_DIR}
+  image-base-url: ${IMAGE_BASE_URL}


### PR DESCRIPTION
1. local에 이미지 저장 후, 경로 반환 로직 구현

(추가 구현 사항)
1. nickname 중복 체크 오류 수정
2. postStats 반환 시, 단위 수정 로직 추가